### PR TITLE
fix(FEC-11377): IE doesn't support replaceAll

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -42,11 +42,11 @@ const ShareButton = (props: Object): React$Element<any> => {
     const {templateUrl, shareUrl, embedUrl} = props.config;
     let href = templateUrl;
 
-    href = href.replaceAll('{description}', props.videoDesc);
+    href = href.replace(/{description}/g, props.videoDesc);
     try {
-      href = href.replaceAll('{shareUrl}', encodeURIComponent(shareUrl));
+      href = href.replace(/{shareUrl}/g, encodeURIComponent(shareUrl));
     } catch (e) {
-      href = href.replaceAll('{shareUrl}', shareUrl);
+      href = href.replace(/{shareUrl}/g, shareUrl);
     }
 
     switch (buttonType) {
@@ -272,7 +272,7 @@ class ShareOverlay extends Component {
     if (this.state.startFrom) {
       url = this._addUrlKalturaStartTimeParam(url);
     }
-    return template.replace(/{embedUrl}/, url);
+    return template.replace(/{embedUrl}/g, url);
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

replaceAll doesn't support on IE11, change to replace with g will replace everything.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
