### PR TITLE
fix(FEC-11253): remove start time from UI when sharing a live stream

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -193,12 +193,21 @@ const VideoStartOptions = (props: Object): React$Element<any> => {
 const COMPONENT_NAME = 'ShareOverlay';
 
 /**
+ * mapping state to props
+ * @param {*} state - redux store state
+ * @returns {Object} - mapped state to this component
+ */
+const mapStateToProps = state => ({
+  isLive: state.engine.isLive
+});
+
+/**
  * ShareOverlay component
  *
  * @class ShareOverlay
  * @extends {Component}
  */
-@connect(null, bindActions(actions))
+@connect(mapStateToProps, bindActions(actions))
 @withLogger(COMPONENT_NAME)
 @withKeyboardA11y
 class ShareOverlay extends Component {
@@ -372,7 +381,7 @@ class ShareOverlay extends Component {
           <div className={shareStyle.shareIcons}>{this._createShareOptions(this.props.config.shareOptions)}</div>
           <div className={shareStyle.linkOptionsContainer}>
             <ShareUrl addAccessibleChild={this.props.addAccessibleChild} shareUrl={this.getShareUrl()} copy={true} isIos={this.isIos} />
-            {this.props.config.enableTimeOffset ? (
+            {this.props.config.enableTimeOffset && !this.props.isLive ? (
               <VideoStartOptions
                 addAccessibleChild={this.props.addAccessibleChild}
                 startFrom={this.state.startFrom}
@@ -399,7 +408,7 @@ class ShareOverlay extends Component {
         <div className={style.title}>{props.title}</div>
         <div className={shareStyle.linkOptionsContainer}>
           <ShareUrl addAccessibleChild={this.props.addAccessibleChild} shareUrl={props.shareUrl} copy={true} isIos={this.isIos} />
-          {this.props.config.enableTimeOffset ? (
+          {this.props.config.enableTimeOffset && !this.props.isLive ? (
             <VideoStartOptions
               addAccessibleChild={this.props.addAccessibleChild}
               startFrom={this.state.startFrom}


### PR DESCRIPTION
### Description of the Changes

Issue: start time check box appears in live.
Solution: don't render it in live.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
