### PR TITLE
fix(FEC-11392): document.querySelector breaks

### DIFF
--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -96,7 +96,7 @@ class Share extends Component {
     if (!(shareUrl && shareOptions)) {
       return undefined;
     }
-    const targetId = document.getElementById(this.props.player.config.targetId);
+    const targetId = document.getElementById(this.props.player.config.targetId) || document;
     const portalSelector = `.overlay-portal`;
     const videoDesc = this._getVideoDesc();
     return this.state.overlayActive ? (

--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -96,12 +96,13 @@ class Share extends Component {
     if (!(shareUrl && shareOptions)) {
       return undefined;
     }
-    const portalSelector = `#${this.props.player.config.targetId} .overlay-portal`;
+    const targetId = document.getElementById(this.props.player.config.targetId);
+    const portalSelector = `.overlay-portal`;
     const videoDesc = this._getVideoDesc();
     return this.state.overlayActive ? (
       createPortal(
         <ShareOverlay config={this.props.config} videoDesc={videoDesc} player={this.props.player} onClose={this.toggleOverlay} />,
-        document.querySelector(portalSelector)
+        targetId.querySelector(portalSelector)
       )
     ) : (
       <ButtonControl name={COMPONENT_NAME}>


### PR DESCRIPTION
### Description of the Changes

Issue: document.querySelector doesn't work correctly when element id contains query chars.
Solution: get element by id and make the query.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
