### PR TITLE
fix(FEC-12266): v7 Share button generates mostly blank email, due to Ampersand

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -42,7 +42,7 @@ const ShareButton = (props: Object): React$Element<any> => {
     const {templateUrl, shareUrl, embedUrl} = props.config;
     let href = templateUrl;
 
-    href = href.replace(/{description}/g, props.videoDesc);
+    href = href.replace(/{description}/g, encodeURIComponent(props.videoDesc));
     try {
       href = href.replace(/{shareUrl}/g, encodeURIComponent(shareUrl));
     } catch (e) {


### PR DESCRIPTION
### Description of the Changes

**the issue:**
when generating email while there is an ampersand char in the video title- the email is blank and the subject and body of the email contains only content until the "&".

**solution:**
encode the video name

Solves FEC-12266

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
