### PR TITLE
fix(FEC-12916): share Plugin Keyboard Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Finally, add the bundle as a script tag in your page, and initialize the player
 
 ```html
 <script type="text/javascript" src="/PATH/TO/FILE/kaltura-{ovp/ott}-player.js"></script>
-<script type="text/javascript" src="/PATH/TO/FILE/playkit-js-share.js"></script>
+<script type="text/javascript" src="/PATH/TO/FILE/playkit-share.js"></script>
 <div id="player-placeholder"" style="height:360px; width:640px">
 <script type="text/javascript">
   var config = {


### PR DESCRIPTION
### Description of the Changes

- disable/enable start from input according to the checkbox
- removing onChange handler of start from input; handle the input only when user focus out of the input element.
- in case the value in the input start time element is longer than video duration- set the startTime to 1 sec.
- fix readme file

Solved FEC-12916

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
