### PR TITLE
fix(FEC-13329): add decodeURI on templateUrl

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -43,7 +43,7 @@ const ShareButton = (props: Object): React$Element<any> => {
   const onClick = (buttonType: string) => {
     const EMAIL = 'email';
     const {templateUrl, shareUrl, embedUrl} = props.config;
-    let href = templateUrl;
+    let href = decodeURIComponent(templateUrl);
 
     href = href.replace(/{description}/g, encodeURIComponent(props.videoDesc));
     try {


### PR DESCRIPTION
### Description of the Changes

- bug fix.

wrap `templateUrl` with `decodeURIComponent` to prevent unsafe HTML tags.

Solves FEC-13329

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
