### PR TITLE
fix(ADA-133): Share - focus should return to plugin button

### DIFF
--- a/src/components/plugin-button/plugin-button.js
+++ b/src/components/plugin-button/plugin-button.js
@@ -36,7 +36,7 @@ class ShareButton extends Component {
     }
     return (
       <Tooltip label={this.props.shareTxt}>
-        <button tabIndex={0} aria-haspopup="true" className={style.upperBarIcon} aria-label={this.props.shareTxt}>
+        <button tabIndex={0} aria-haspopup="true" className={style.upperBarIcon} aria-label={this.props.shareTxt} ref={this.props.setRef}>
           <Icon id={pluginName} path={ICON_PATH} />
         </button>
       </Tooltip>

--- a/src/share.js
+++ b/src/share.js
@@ -12,6 +12,7 @@ import {ShareEvent} from './event';
 const {ReservedPresetNames} = ui;
 const {Utils} = core;
 const {Text} = ui.preacti18n;
+const {focusElement} = ui.Utils;
 const pluginName: string = 'share';
 /**
  * The Share plugin.
@@ -33,6 +34,8 @@ class Share extends BasePlugin {
     enableTimeOffset: true,
     enableClipping: true
   };
+
+  _pluginButtonRef: HTMLButtonElement | null = null;
 
   /**
    * Whether the Share plugin is valid.
@@ -65,7 +68,7 @@ class Share extends BasePlugin {
 
   _addIcon() {
     this.player.ready().then(() => {
-      const ShareWrapper = () => <ShareButton config={this.config} />;
+      const ShareWrapper = () => <ShareButton config={this.config} setRef={this._setPluginButtonRef} />;
       this.iconId = this.player.getService('upperBarManager').add({
         label: <Text id="controls.share">Share</Text>,
         component: ShareWrapper,
@@ -104,12 +107,21 @@ class Share extends BasePlugin {
     }
   }
 
-  _closeShareOverlay() {
+  _closeShareOverlay(event?: OnClickEvent, byKeyboard?: boolean) {
     this._removeOverlay();
     if (this._wasPlayed) {
       this.player.play();
       this._wasPlayed = false;
     }
+    if (byKeyboard) {
+      // TODO: add focusElement to ts-typed
+      // @ts-ignore
+      focusElement(this._pluginButtonRef, 100);
+    }
+  }
+
+  _setPluginButtonRef(ref: HTMLButtonElement | null) {
+    this._pluginButtonRef = ref;
   }
 
   _setOverlay(fn: Function) {


### PR DESCRIPTION
### Description of the Changes

Focus should return to plugin button after close the modal by keyboard

solves [ADA-133](https://kaltura.atlassian.net/browse/ADA-133)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
