### PR TITLE
fix(FEC-13844): do not render clipping options for audio player

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -675,7 +675,7 @@ class ShareOverlay extends Component {
               isIos={this.isIos}
               videoClippingOption={this.state.videoClippingOption}
             />
-            {this.props.activePresetName !== ReservedPresetNames.MiniAudioUI && this._renderVideoClippingOptions()}
+            {this._renderVideoClippingOptions()}
           </div>
         </div>
       </div>
@@ -689,7 +689,9 @@ class ShareOverlay extends Component {
    * @memberof ShareOverlay
    */
   _renderVideoClippingOptions(): React$Element<any> {
-    return (this.props.config.enableTimeOffset || this.props.config.enableClipping) && !this.props.isLive ? (
+    return (this.props.config.enableTimeOffset || this.props.config.enableClipping) &&
+      !this.props.isLive &&
+      this.props.activePresetName !== ReservedPresetNames.MiniAudioUI ? (
       <VideoStartOptions
         addAccessibleChild={this.props.addAccessibleChild}
         startFromValue={this.state.startFromValue}


### PR DESCRIPTION
### Description of the Changes

do not render clipping options for audio player.

Solves FEC-13844

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
