### PR TITLE
fix(ADA-1734): Continues ADA-1500, Added Localizer

### DIFF
--- a/src/share.js
+++ b/src/share.js
@@ -12,7 +12,7 @@ import {ShareButton} from './components/plugin-button/plugin-button';
 import {ShareEvent} from './event';
 const {ReservedPresetNames} = ui;
 const {Utils} = core;
-const {Text} = ui.preacti18n;
+const {Text, Localizer} = ui.preacti18n;
 const {focusElement} = ui.Utils;
 const pluginName: string = 'share';
 /**
@@ -76,7 +76,14 @@ class Share extends BasePlugin {
         const ShareWrapper = () => <ShareButton config={this.config} setRef={this._setPluginButtonRef.bind(this)} />;
         this.iconId = this.player.getService('upperBarManager').add({
           displayName: 'Share',
-          ariaLabel: <Text id="controls.share">Share</Text>,
+          ariaLabel: () => {
+            const textJSX = (
+              <Localizer>
+                <Text id="controls.share">Share</Text>
+              </Localizer>
+            );
+            return textJSX
+          },
           order: 70,
           component: ShareWrapper,
           svgIcon: {path: ICON_PATH},


### PR DESCRIPTION
**With:**
- Other Plugins involved:
https://github.com/kaltura/playkit-js-info/pull/104
https://github.com/kaltura/playkit-js-downloads/pull/73
https://github.com/kaltura/playkit-js-moderation/pull/95

- For JSX conversion is required this PR that adds "preact-render-to-string" library:

**Issue:**:
Previous JSX was not translated when loaded in the ui-managers
This was causing aria-label to be rendered: [Object object]

**Fix**:
For translation added Localizer component as well

**Question**:
Compiling this plugin also generated these files:
playkit-share.js
playkit-share.js.map
Should I add them to the PR as well ? 
