### PR TITLE
fix(SUP-45956): [Wells Fargo] Share clip on V7 not working on KMS after re-sharing

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -477,6 +477,26 @@ class ShareOverlay extends Component {
   }
 
   /**
+   * update url with params and values
+   *
+   * @param {string} url - the share url
+   * @param {string} key - the param name
+   * @param {string} value - the param value
+   * @returns {string} - share url with the query parameters
+   * @memberof ShareOverlay
+   */
+  _updateUrlParams(url: string, key: string, value: number): string {
+    const urlObj = new URL(url);
+    const searchParams = urlObj.searchParams;
+    if (searchParams.has(key)) {
+      searchParams.set(key, value);
+    } else {
+      searchParams.append(key, value);
+    }
+    return urlObj.toString();
+  }
+
+  /**
    * add seekFrom and clipTo query parameters to share url
    *
    * @param {string} url - the share url
@@ -484,8 +504,8 @@ class ShareOverlay extends Component {
    * @memberof ShareOverlay
    */
   _addKalturaClipParams(url: string): string {
-    const params = `kalturaSeekFrom=${this.state.clipStartTimeValue}&kalturaClipTo=${this.state.clipEndTimeValue}`;
-    return url.indexOf('?') === -1 ? `${url}?${params}` : `${url}&${params}`;
+    url = this._updateUrlParams(url, 'kalturaStartTime', this.state.clipStartTimeValue);
+    return this._updateUrlParams(url, 'kalturaClipTo', this.state.clipEndTimeValue);
   }
 
   /**
@@ -496,8 +516,7 @@ class ShareOverlay extends Component {
    * @memberof ShareOverlay
    */
   _addUrlKalturaStartTimeParam(url: string): string {
-    const param = `kalturaStartTime=${this.state.startFromValue}`;
-    return url.indexOf('?') === -1 ? `${url}?${param}` : `${url}&${param}`;
+    return this._updateUrlParams(url, 'kalturaStartTime', this.state.startFromValue);
   }
 
   /**

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -497,6 +497,7 @@ class ShareOverlay extends Component {
       return urlObj.toString();
     } catch (e) {
       this.props.logger.log(e);
+      return '';
     }
   }
 

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -486,14 +486,18 @@ class ShareOverlay extends Component {
    * @memberof ShareOverlay
    */
   _updateUrlParams(url: string, key: string, value: number): string {
-    const urlObj = new URL(url);
-    const searchParams = urlObj.searchParams;
-    if (searchParams.has(key)) {
-      searchParams.set(key, value);
-    } else {
-      searchParams.append(key, value);
+    try {
+      const urlObj = new URL(url);
+      const searchParams = urlObj.searchParams;
+      if (searchParams.has(key)) {
+        searchParams.set(key, value);
+      } else {
+        searchParams.append(key, value);
+      }
+      return urlObj.toString();
+    } catch (e) {
+      this.props.logger.log(e);
     }
-    return urlObj.toString();
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When using share clip option and open the new url, using the share clip again won't work - the video times will remain as the first clip.

**Root cause:** 
the kalturaSeekFrom and the kalturaClipTo params are appended again and again to the url and not replace the older values.

**Fix:**
Check if the param already exist on the url then replace the value or append it accordingly.

Solves [SUP-45956](https://kaltura.atlassian.net/browse/SUP-45956)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-45956]: https://kaltura.atlassian.net/browse/SUP-45956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ