### PR TITLE
fix(FEC-14031): SHARE_EMBED_CLOSE is being sent upon every entry change in playlist

### DIFF
--- a/src/share.js
+++ b/src/share.js
@@ -123,14 +123,20 @@ class Share extends BasePlugin {
           area: 'GuiArea',
           presets: [ReservedPresetNames.Playback, ReservedPresetNames.Live, ReservedPresetNames.MiniAudioUI],
           // eslint-disable-next-line react/display-name
-          get: () => <ShareComponent onClose={this._closeShareOverlay.bind(this)} config={this.config} videoDesc={videoDesc} />
+          get: () => (
+            <ShareComponent
+              onClose={(event, byKeyboard) => this._closeShareOverlay(event, byKeyboard, true)}
+              config={this.config}
+              videoDesc={videoDesc}
+            />
+          )
         })
       );
     }
     this.dispatchEvent(ShareEvent.SHARE_CLICKED);
   }
 
-  _closeShareOverlay(event?: OnClickEvent, byKeyboard?: boolean) {
+  _closeShareOverlay(event?: OnClickEvent, byKeyboard?: boolean, userInteraction = false) {
     this._removeOverlay();
     if (this._wasPlayed) {
       this.player.play();
@@ -141,7 +147,9 @@ class Share extends BasePlugin {
       // @ts-ignore
       focusElement(this._pluginButtonRef);
     }
-    this.dispatchEvent(ShareEvent.SHARE_CLOSE);
+    if (userInteraction) {
+      this.dispatchEvent(ShareEvent.SHARE_CLOSE);
+    }
   }
 
   _setPluginButtonRef(ref: HTMLButtonElement | null) {


### PR DESCRIPTION
### Description of the Changes

- Added a new boolean variable called 'userInteraction' with default value 'false' to function '_closeShareOverlay'.
- The function '_closeShareOverlay' gets 'userInteraction =  true' only in places where the user in fact
 clicked the button to close the share view.

[FEC-14031](https://kaltura.atlassian.net/browse/FEC-14031)


[FEC-14031]: https://kaltura.atlassian.net/browse/FEC-14031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ