### PR TITLE
feat(FEC-14553): When no transcoding flavors are available, use the start at parameter instead of the player's clipping capability

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -534,7 +534,11 @@ class ShareOverlay extends Component {
   _addKalturaClipParams(url: string): string {
     url = this._updateUrlParams(url, 'kalturaSeekFrom', cropTimeForFrames(this.state.clipStartTimeValue));
     url = this._updateUrlParams(url, 'kalturaClipTo', this.state.clipEndTimeValue);
-    return this._updateUrlParams(url, 'kalturaStartTime', this.state.clipOriginalStartTimeValue % 2);
+    if (this.props.player.config.sources.dash.length === 0 && this.props.player.config.sources.hls.length === 0) {
+      return this._updateUrlParams(url, 'kalturaStartTime', cropTimeForFrames(this.state.clipStartTimeValue));
+    } else {
+      return this._updateUrlParams(url, 'kalturaStartTime', this.state.clipOriginalStartTimeValue % 2);
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

- Updates the `_addKalturaClipParams` method in `share-overlay.js` to refine URL parameter handling.
- Adds a conditional check for empty DASH and HLS sources arrays.
- If both DASH and HLS sources are empty, sets `kalturaStartTime` using `clipStartTimeValue`.
- Otherwise, sets `kalturaStartTime` using the modulo of `clipOriginalStartTimeValue`.
- Improves generation of share URLs for different streaming source scenarios.

[FEC-14553](https://kaltura.atlassian.net/browse/FEC-14553)


[FEC-14553]: https://kaltura.atlassian.net/browse/FEC-14553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ