### PR TITLE
fix(FEC-14871): KAF - AEM - Improvement - Users do not copy the correct info when using the share option

### DIFF
--- a/src/components/share-overlay/_share-overlay.scss
+++ b/src/components/share-overlay/_share-overlay.scss
@@ -160,6 +160,30 @@
   }
 }
 
+.player.size-ty {
+  .overlay.share-overlay {
+    .link-options-container {
+      .copy-url-row {
+        .control-copy-button {
+          display: inline-block !important;
+        }
+      }
+    }
+  }
+}
+
+.hidden-input {
+  position: absolute;
+  left: -9999px;
+}
+
+.copy-url-text {
+  display: flex;
+  align-items: center;
+  font-size: 14px;
+  color: $tone-1-color
+}
+
 .startAtInput {
   text-align: center;
   border: 1px solid rgba(255, 255, 255, 0.4);

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -796,7 +796,7 @@ class ShareOverlay extends Component {
             videoClippingOption={this.state.videoClippingOption}
             copy={true}
             isIos={this.isIos}
-            isTiny={this.props.playerSize === 'size-ty'}
+            isTiny={this.props.playerSize === 'tiny'}
           />
           {this._renderVideoClippingOptions()}
         </div>

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -24,6 +24,7 @@ const shareOverlayView: Object = {
 };
 
 const EMBED = 'embed';
+const TINY = 'tiny';
 /**
  * ShareButton component
  * @param {Object} props - the class props
@@ -742,7 +743,7 @@ class ShareOverlay extends Component {
               copy={true}
               isIos={this.isIos}
               videoClippingOption={this.state.videoClippingOption}
-              isTiny={this.props.playerSize === 'tiny'}
+              isTiny={this.props.playerSize === TINY}
             />
             {this._renderVideoClippingOptions()}
           </div>
@@ -796,7 +797,7 @@ class ShareOverlay extends Component {
             videoClippingOption={this.state.videoClippingOption}
             copy={true}
             isIos={this.isIos}
-            isTiny={this.props.playerSize === 'tiny'}
+            isTiny={this.props.playerSize === TINY}
           />
           {this._renderVideoClippingOptions()}
         </div>

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -122,7 +122,9 @@ const ShareUrl = (props: Object): React$Element<any> => {
 
   return (
     <div className={props.copy ? style.copyUrlRow : ''}>
-      <div className={[style.formGroup, style.inputCopyUrl].join(' ')} style="width: 100%;">
+      <div
+        className={[props.isTiny ? shareStyle.hiddenInput : style.formGroup, style.inputCopyUrl].join(' ')}
+        style={props.isTiny ? '' : 'width: 100%;'}>
         <input
           tabIndex="-1"
           type="text"
@@ -133,6 +135,11 @@ const ShareUrl = (props: Object): React$Element<any> => {
           readOnly
         />
       </div>
+      {props.isTiny && (
+        <div className={shareStyle.copyUrlText}>
+          <Text id="share.copy_url" />
+        </div>
+      )}
       {props.copy && <CopyButton addAccessibleChild={props.addAccessibleChild} copy={copyUrl} />}
     </div>
   );
@@ -432,7 +439,8 @@ const COMPONENT_NAME = 'ShareOverlay';
  */
 const mapStateToProps = state => ({
   isLive: state.engine.isLive,
-  activePresetName: state.shell.activePresetName
+  activePresetName: state.shell.activePresetName,
+  playerSize: state.shell.playerSize
 });
 
 const PLAYER_WIDTH_EMBED_DEFAULT = '560';
@@ -734,6 +742,7 @@ class ShareOverlay extends Component {
               copy={true}
               isIos={this.isIos}
               videoClippingOption={this.state.videoClippingOption}
+              isTiny={this.props.playerSize === 'tiny'}
             />
             {this._renderVideoClippingOptions()}
           </div>
@@ -787,6 +796,7 @@ class ShareOverlay extends Component {
             videoClippingOption={this.state.videoClippingOption}
             copy={true}
             isIos={this.isIos}
+            isTiny={this.props.playerSize === 'size-ty'}
           />
           {this._renderVideoClippingOptions()}
         </div>

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -17,7 +17,8 @@
       "clip_to": "Clip to",
       "share-on-facebook": "Share on Facebook",
       "share-on-linkedin": "Share on Linkedin",
-      "share-on-twitter": "Share on X"
+      "share-on-twitter": "Share on X",
+      "copy_url": "Copy URL"
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

**Issue:**
When player is tiny the copy url button is hidden and clicking the player copy the debug info instead of url.

**Fix:** 
Force showing the copy url button, hide the input element and show "copy URL" text instead.

solves [FEC-14871](https://kaltura.atlassian.net/browse/FEC-14871)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14871]: https://kaltura.atlassian.net/browse/FEC-14871?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ