### PR TITLE
feat(CR-608): Add share chapter button to player plugin

### DIFF
--- a/src/components/share-overlay/_share-overlay.scss
+++ b/src/components/share-overlay/_share-overlay.scss
@@ -181,7 +181,7 @@
   display: flex;
   align-items: center;
   font-size: 14px;
-  color: $tone-1-color
+  color: $tone-1-color;
 }
 
 .startAtInput {
@@ -192,4 +192,12 @@
     background-color: rgba(0, 0, 0, 0.3);
     border: 1px solid rgba(255, 255, 255, 0.3);
   }
+}
+
+.shared-chapter-info {
+  font-weight: 700;
+  font-size: 14px;
+  line-height: 18px;
+  margin-bottom: 16px;
+  margin-top: 16px;
 }

--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -475,10 +475,11 @@ class ShareOverlay extends Component {
    */
   componentWillMount() {
     this.isIos = this.props.player.env.os.name === 'iOS';
+    const times = this._getTimeValues();
     this.setState({
       view: shareOverlayView.Main,
-      startFromValue: Math.floor(this.props.player.currentTime),
-      videoClippingOption: VIDEO_CLIPPING_OPTIONS.FULL_VIDEO,
+      startFromValue: times.startFromTime,
+      videoClippingOption: times.videoClippingOption,
       clipStartTimeValue: cropTimeForFrames(this.props.player.currentTime),
       clipOriginalStartTimeValue: Math.floor(this.props.player.currentTime),
       clipEndTimeValue: Math.floor(this.props.player.duration)
@@ -508,6 +509,23 @@ class ShareOverlay extends Component {
     this.props.setIsModal(true);
   }
 
+  /**
+   * Get time values for video clipping
+   * @returns {Object} - startFromTime and videoClippingOption
+   * @memberof ShareOverlay
+   */
+  _getTimeValues() {
+    const {chapterTime} = this.props.chapterInfo || {};
+    let startFromTime, videoClippingOption;
+    if (chapterTime !== undefined) {
+      startFromTime = Math.floor(chapterTime);
+      videoClippingOption = VIDEO_CLIPPING_OPTIONS.START_FROM;
+    } else {
+      startFromTime = Math.floor(this.props.player.currentTime);
+      videoClippingOption = VIDEO_CLIPPING_OPTIONS.FULL_VIDEO;
+    }
+    return {startFromTime, videoClippingOption};
+  }
   /**
    * update url with params and values
    *
@@ -724,6 +742,24 @@ class ShareOverlay extends Component {
   }
 
   /**
+   * renders the chapter info if exists
+   * @returns {React$Element<any>|null} - the chapter info element
+   * @private
+   */
+  _renderChapterInfo(): React$Element<any> | null {
+    const {chapterTime, chapterTitle} = this.props.chapterInfo;
+    if (chapterTime === undefined && chapterTitle === undefined) {
+      return null;
+    }
+    return (
+      <div className={shareStyle.sharedChapterInfo}>
+        {chapterTime !== undefined && <Text id="share.start_at" fields={{chapterTime: toHHMMSS(chapterTime)}} />}
+        {chapterTitle !== undefined && <span>{chapterTitle}</span>}
+      </div>
+    );
+  }
+
+  /**
    * renders main overlay state
    *
    * @returns {React$Element} - main state element
@@ -735,6 +771,7 @@ class ShareOverlay extends Component {
         <div className={shareStyle.header}>{<Text id="share.title" />}</div>
         <div className={shareStyle.shareMainContainer}>
           <div className={shareStyle.shareIcons}>{this._createShareOptions(this.props.config.shareOptions)}</div>
+          {this._renderChapterInfo()}
           <div className={shareStyle.linkOptionsContainer}>
             <ShareUrl
               player={this.props.player}

--- a/src/components/share/share.js
+++ b/src/components/share/share.js
@@ -55,7 +55,13 @@ class Share extends Component {
     const targetId = document.getElementById(this.props.player.config.targetId) || document;
     const portalSelector = `.overlay-portal`;
     return createPortal(
-      <ShareOverlay config={this.props.config} videoDesc={this.props.videoDesc} player={this.props.player} onClose={this.props.onClose} />,
+      <ShareOverlay
+        config={this.props.config}
+        videoDesc={this.props.videoDesc}
+        player={this.props.player}
+        onClose={this.props.onClose}
+        chapterInfo={this.props.chapterInfo}
+      />,
       targetId.querySelector(portalSelector)
     );
   }

--- a/src/share.js
+++ b/src/share.js
@@ -69,6 +69,7 @@ class Share extends BasePlugin {
     }
     this._wasPlayed = false; // keep state of the player so we can resume if needed
     this._addIcon();
+    this._addChapterSharedListener();
   }
 
   _addIcon() {
@@ -92,6 +93,18 @@ class Share extends BasePlugin {
     }
   }
 
+  /**
+   * Add listener for chapter shared event
+   * @returns {void}
+   * @memberof Share
+   */
+  _addChapterSharedListener() {
+    this.player.addEventListener('summary_chapters_chapter_shared', (event: any) => {
+      const chapterInfo = {chapterTime: event?.payload?.time, chapterTitle: event?.payload?.title};
+      this._openShareOverlay(chapterInfo);
+    });
+  }
+
   _getVideoDesc(): string {
     let name = coreUtils.Object.getPropertyPath(this.player.config, 'sources.metadata.name') || 'the video';
     return `${name}`;
@@ -101,7 +114,7 @@ class Share extends BasePlugin {
     this._openShareOverlay();
   }
 
-  _openShareOverlay() {
+  _openShareOverlay(chapterInfo?: Object) {
     if (!this.player.paused) {
       this.player.pause();
       this._wasPlayed = true;
@@ -128,6 +141,7 @@ class Share extends BasePlugin {
               onClose={(event, byKeyboard) => this._closeShareOverlay(event, byKeyboard, true)}
               config={this.config}
               videoDesc={videoDesc}
+              chapterInfo={chapterInfo}
             />
           )
         })

--- a/src/share.js
+++ b/src/share.js
@@ -99,7 +99,7 @@ class Share extends BasePlugin {
    * @memberof Share
    */
   _addChapterSharedListener() {
-    this.player.addEventListener('summary_chapters_chapter_shared', (event: any) => {
+    this.player.addEventListener('summary_chapters_chapter_share', (event: any) => {
       const chapterInfo = {chapterTime: event?.payload?.time, chapterTitle: event?.payload?.title};
       this._openShareOverlay(chapterInfo);
     });

--- a/translations/en.i18n.json
+++ b/translations/en.i18n.json
@@ -18,7 +18,8 @@
       "share-on-facebook": "Share on Facebook",
       "share-on-linkedin": "Share on Linkedin",
       "share-on-twitter": "Share on X",
-      "copy_url": "Copy URL"
+      "copy_url": "Copy URL",
+      "start_at": "Start video at {{chapterTime}}"
     }
   }
 }


### PR DESCRIPTION
### Description of the Changes

when summary_chapters_chapter_shared event is triggered (share button from S&C is clicked) open the share overlay and change the copy url to start from the chapter start time.
Also adding the chapter start time and the chapter title after the share options icons.

related pr - https://github.com/kaltura/unisphere-video-summary/pull/109, https://github.com/kaltura/playkit-js-unisphere/pull/28

solves [CR-608](https://kaltura.atlassian.net/browse/CR-608)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[CR-608]: https://kaltura.atlassian.net/browse/CR-608?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ