### PR TITLE
fix(FEC-14975): Add share chapter button to player plugin | No space between the time of "Start video at", and the chapter title inside share plugin overlay.

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -754,7 +754,7 @@ class ShareOverlay extends Component {
     return (
       <div className={shareStyle.sharedChapterInfo}>
         {chapterTime !== undefined && <Text id="share.start_at" fields={{chapterTime: toHHMMSS(chapterTime)}} />}
-        {chapterTitle !== undefined && <span>{chapterTitle}</span>}
+        {chapterTitle !== undefined && <span>{` ${chapterTitle}`}</span>}
       </div>
     );
   }


### PR DESCRIPTION
### Description of the Changes

Adding space before chapter name

solves [FEC-14975](https://kaltura.atlassian.net/browse/FEC-14975)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14975]: https://kaltura.atlassian.net/browse/FEC-14975?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ