### PR TITLE
fix(FEC-14981): Player V7| automation| Audio player share plugin failed to load

### DIFF
--- a/src/components/share-overlay/share-overlay.js
+++ b/src/components/share-overlay/share-overlay.js
@@ -747,7 +747,7 @@ class ShareOverlay extends Component {
    * @private
    */
   _renderChapterInfo(): React$Element<any> | null {
-    const {chapterTime, chapterTitle} = this.props.chapterInfo;
+    const {chapterTime, chapterTitle} = this.props.chapterInfo || {};
     if (chapterTime === undefined && chapterTitle === undefined) {
       return null;
     }


### PR DESCRIPTION
### Description of the Changes

audio player doesn't have a chapterInfo props

solves [FEC-14981](https://kaltura.atlassian.net/browse/FEC-14981) 

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[FEC-14981]: https://kaltura.atlassian.net/browse/FEC-14981?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ